### PR TITLE
Fix game sequence and math question display

### DIFF
--- a/mountain_dung_dodger.html
+++ b/mountain_dung_dodger.html
@@ -290,7 +290,7 @@
                 <div class="progressFill" id="mathProgress"></div>
             </div>
             <p id="mathInstructions">Solve the math problem to continue!</p>
-            <div class="mathProblem" id="mathProblem">5 + 3 = ?</div>
+            <div class="mathProblem" id="mathProblem"></div>
             <input type="number" class="mathInput" id="mathAnswer" placeholder="?" min="0" max="999">
             <button class="mathSubmit" onclick="submitMathAnswer()">Submit Answer</button>
             <div id="mathResult"></div>
@@ -354,6 +354,11 @@
         // Math problem generator
         function generateMathProblem(difficulty) {
             let problem, answer;
+            
+            // Ensure difficulty is valid
+            if (!difficulty || difficulty < 1 || difficulty > 5) {
+                difficulty = 1; // Default to grade 1
+            }
             
             switch(difficulty) {
                 case 1: // Grade 1: Addition up to 10
@@ -445,9 +450,23 @@
             mathSessionActive = true;
             mathExerciseCount = 0;
             mathCorrectAnswers = 0;
+            
+            // Debug logging
+            console.log('Starting math exercise with difficulty:', selectedDifficulty);
+            
             currentMathProblem = generateMathProblem(selectedDifficulty);
             
-            document.getElementById('mathProblem').textContent = currentMathProblem.problem;
+            // Ensure the math problem is properly displayed
+            if (currentMathProblem && currentMathProblem.problem) {
+                document.getElementById('mathProblem').textContent = currentMathProblem.problem;
+                console.log('Math problem set:', currentMathProblem.problem);
+            } else {
+                // Fallback if problem generation fails
+                currentMathProblem = { problem: "5 + 3 = ?", answer: 8 };
+                document.getElementById('mathProblem').textContent = currentMathProblem.problem;
+                console.log('Fallback math problem set:', currentMathProblem.problem);
+            }
+            
             document.getElementById('mathAnswer').value = '';
             document.getElementById('mathResult').innerHTML = '';
             document.getElementById('mathInstructions').textContent = `Solve the math problem to continue! (${mathExerciseCount + 1}/3)`;
@@ -474,7 +493,14 @@
             if (mathExerciseCount < 3) {
                 setTimeout(() => {
                     currentMathProblem = generateMathProblem(selectedDifficulty);
-                    document.getElementById('mathProblem').textContent = currentMathProblem.problem;
+                    // Ensure the math problem is properly displayed
+                    if (currentMathProblem && currentMathProblem.problem) {
+                        document.getElementById('mathProblem').textContent = currentMathProblem.problem;
+                    } else {
+                        // Fallback if problem generation fails
+                        currentMathProblem = { problem: "5 + 3 = ?", answer: 8 };
+                        document.getElementById('mathProblem').textContent = currentMathProblem.problem;
+                    }
                     document.getElementById('mathAnswer').value = '';
                     document.getElementById('mathResult').innerHTML = '';
                     document.getElementById('mathInstructions').textContent = `Solve the math problem to continue! (${mathExerciseCount + 1}/3)`;
@@ -509,6 +535,15 @@
             
             if (gameState === 'math') {
                 gameState = 'playing';
+                // Reset player position to safe ground after math session
+                player.x = 50;
+                player.y = 300;
+                player.vx = 0;
+                player.vy = 0;
+                player.onGround = false;
+                
+                // Debug logging
+                console.log('Player position reset after math session:', player.x, player.y);
             }
         }
         
@@ -709,6 +744,10 @@
                 
                 // Start math exercise between levels
                 gameState = 'math';
+                // Ensure difficulty is set before starting math
+                if (selectedDifficulty === 0) {
+                    selectedDifficulty = 1; // Default to grade 1 if not set
+                }
                 startMathExercise();
             }
             
@@ -854,6 +893,11 @@
             mathProblemsSolved = 0;
             updateHUD();
             generateLevel(level);
+            
+            // Ensure difficulty is set for new games
+            if (selectedDifficulty === 0) {
+                selectedDifficulty = 1; // Default to grade 1
+            }
         }
         
         function gameOver() {
@@ -866,7 +910,8 @@
         
         function resetGame() {
             document.getElementById('gameOverScreen').classList.add('hidden');
-            selectedDifficulty = 0;
+            // Don't reset difficulty when restarting - keep the same difficulty
+            // selectedDifficulty = 0;
             startGame();
         }
         

--- a/mountain_dung_dodger.html
+++ b/mountain_dung_dodger.html
@@ -451,20 +451,15 @@
             mathExerciseCount = 0;
             mathCorrectAnswers = 0;
             
-            // Debug logging
-            console.log('Starting math exercise with difficulty:', selectedDifficulty);
-            
             currentMathProblem = generateMathProblem(selectedDifficulty);
             
             // Ensure the math problem is properly displayed
             if (currentMathProblem && currentMathProblem.problem) {
                 document.getElementById('mathProblem').textContent = currentMathProblem.problem;
-                console.log('Math problem set:', currentMathProblem.problem);
             } else {
                 // Fallback if problem generation fails
                 currentMathProblem = { problem: "5 + 3 = ?", answer: 8 };
                 document.getElementById('mathProblem').textContent = currentMathProblem.problem;
-                console.log('Fallback math problem set:', currentMathProblem.problem);
             }
             
             document.getElementById('mathAnswer').value = '';
@@ -542,9 +537,6 @@
                 player.vx = 0;
                 player.vy = 0;
                 player.onGround = false; // Let collision detection set this
-                
-                // Debug logging
-                console.log('Player position reset after math session:', player.x, player.y, 'onGround:', player.onGround);
             }
         }
         

--- a/mountain_dung_dodger.html
+++ b/mountain_dung_dodger.html
@@ -355,9 +355,9 @@
         function generateMathProblem(difficulty) {
             let problem, answer;
             
-            // Ensure difficulty is valid
+            // Default to grade 1 if difficulty is invalid
             if (!difficulty || difficulty < 1 || difficulty > 5) {
-                difficulty = 1; // Default to grade 1
+                difficulty = 1;
             }
             
             switch(difficulty) {
@@ -452,15 +452,7 @@
             mathCorrectAnswers = 0;
             
             currentMathProblem = generateMathProblem(selectedDifficulty);
-            
-            // Ensure the math problem is properly displayed
-            if (currentMathProblem && currentMathProblem.problem) {
-                document.getElementById('mathProblem').textContent = currentMathProblem.problem;
-            } else {
-                // Fallback if problem generation fails
-                currentMathProblem = { problem: "5 + 3 = ?", answer: 8 };
-                document.getElementById('mathProblem').textContent = currentMathProblem.problem;
-            }
+            document.getElementById('mathProblem').textContent = currentMathProblem.problem;
             
             document.getElementById('mathAnswer').value = '';
             document.getElementById('mathResult').innerHTML = '';
@@ -488,14 +480,7 @@
             if (mathExerciseCount < 3) {
                 setTimeout(() => {
                     currentMathProblem = generateMathProblem(selectedDifficulty);
-                    // Ensure the math problem is properly displayed
-                    if (currentMathProblem && currentMathProblem.problem) {
-                        document.getElementById('mathProblem').textContent = currentMathProblem.problem;
-                    } else {
-                        // Fallback if problem generation fails
-                        currentMathProblem = { problem: "5 + 3 = ?", answer: 8 };
-                        document.getElementById('mathProblem').textContent = currentMathProblem.problem;
-                    }
+                    document.getElementById('mathProblem').textContent = currentMathProblem.problem;
                     document.getElementById('mathAnswer').value = '';
                     document.getElementById('mathResult').innerHTML = '';
                     document.getElementById('mathInstructions').textContent = `Solve the math problem to continue! (${mathExerciseCount + 1}/3)`;
@@ -531,12 +516,11 @@
             if (gameState === 'math') {
                 gameState = 'playing';
                 // Reset player position to safe ground after math session
-                // Position player slightly above the starting platform so collision detection can catch them
                 player.x = 50;
-                player.y = 350; // Slightly above the platform so collision detection works
+                player.y = 350;
                 player.vx = 0;
                 player.vy = 0;
-                player.onGround = false; // Let collision detection set this
+                player.onGround = false;
             }
         }
         
@@ -641,10 +625,10 @@
             
             // Reset player
             player.x = 50;
-            player.y = 350; // Slightly above the platform so collision detection works
+            player.y = 350;
             player.vx = 0;
             player.vy = 0;
-            player.onGround = false; // Let collision detection set this
+            player.onGround = false;
             player.invulnerable = 0;
         }
         
@@ -744,10 +728,6 @@
                 
                 // Start math exercise between levels
                 gameState = 'math';
-                // Ensure difficulty is set before starting math
-                if (selectedDifficulty === 0) {
-                    selectedDifficulty = 1; // Default to grade 1 if not set
-                }
                 startMathExercise();
             }
             
@@ -772,10 +752,10 @@
                     gameOver();
                 } else {
                     player.x = 50;
-                    player.y = 350; // Slightly above the platform so collision detection works
+                    player.y = 350;
                     player.vx = 0;
                     player.vy = 0;
-                    player.onGround = false; // Let collision detection set this
+                    player.onGround = false;
                 }
             }
         }
@@ -894,11 +874,6 @@
             mathProblemsSolved = 0;
             updateHUD();
             generateLevel(level);
-            
-            // Ensure difficulty is set for new games
-            if (selectedDifficulty === 0) {
-                selectedDifficulty = 1; // Default to grade 1
-            }
         }
         
         function gameOver() {

--- a/mountain_dung_dodger.html
+++ b/mountain_dung_dodger.html
@@ -579,6 +579,9 @@
         function selectDifficulty(difficulty) {
             selectedDifficulty = difficulty;
             document.getElementById('difficultyScreen').classList.add('hidden');
+            // First start the game to generate the level and platforms
+            startGame();
+            // Then start the math exercise
             startMathExercise();
         }
         

--- a/mountain_dung_dodger.html
+++ b/mountain_dung_dodger.html
@@ -536,14 +536,15 @@
             if (gameState === 'math') {
                 gameState = 'playing';
                 // Reset player position to safe ground after math session
+                // Position player slightly above the starting platform so collision detection can catch them
                 player.x = 50;
-                player.y = 300;
+                player.y = 350; // Slightly above the platform so collision detection works
                 player.vx = 0;
                 player.vy = 0;
-                player.onGround = false;
+                player.onGround = false; // Let collision detection set this
                 
                 // Debug logging
-                console.log('Player position reset after math session:', player.x, player.y);
+                console.log('Player position reset after math session:', player.x, player.y, 'onGround:', player.onGround);
             }
         }
         
@@ -645,10 +646,10 @@
             
             // Reset player
             player.x = 50;
-            player.y = 300;
+            player.y = 350; // Slightly above the platform so collision detection works
             player.vx = 0;
             player.vy = 0;
-            player.onGround = false;
+            player.onGround = false; // Let collision detection set this
             player.invulnerable = 0;
         }
         
@@ -677,6 +678,8 @@
             player.x += player.vx;
             player.y += player.vy;
             
+
+            
             // Platform collision
             player.onGround = false;
             for (let plat of platforms) {
@@ -693,6 +696,8 @@
                     }
                 }
             }
+            
+
             
             // Dung collision
             if (player.invulnerable <= 0) {
@@ -772,9 +777,10 @@
                     gameOver();
                 } else {
                     player.x = 50;
-                    player.y = 300;
+                    player.y = 350; // Slightly above the platform so collision detection works
                     player.vx = 0;
                     player.vy = 0;
+                    player.onGround = false; // Let collision detection set this
                 }
             }
         }


### PR DESCRIPTION
Reset player position after math sessions and ensure consistent math problem display across game states.

---
<a href="https://cursor.com/background-agent?bcId=bc-74615b54-76b7-45ce-a53a-f80e48702685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74615b54-76b7-45ce-a53a-f80e48702685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

