### PR TITLE
fix: make finishMathSession idempotent to prevent double-counting

### DIFF
--- a/math/mathTests.js
+++ b/math/mathTests.js
@@ -166,10 +166,23 @@ class MathTests {
     }
 
     /**
-     * Finish the current math session
+     * Finish the current math session.
+     * Idempotent: if the session is already finished (sessionActive is false)
+     * this is a no-op that returns the same summary without double-counting.
      * @returns {object} Session summary
      */
     finishMathSession() {
+        if (!this.sessionActive) {
+            // Session already finished — return current stats without modifying them
+            return {
+                totalExercises: this.exercisesPerSession,
+                correctAnswers: this.correctAnswers,
+                accuracy: this.exercisesPerSession > 0
+                    ? (this.correctAnswers / this.exercisesPerSession) * 100
+                    : 0,
+                problemsSolved: this.problemsSolved
+            };
+        }
         this.sessionActive = false;
         this.problemsSolved += this.correctAnswers;
         


### PR DESCRIPTION
## Summary

- `finishMathSession()` was called twice per session: once inside `submitMathAnswer()` on the final answer, and again by every game wrapper (`elemental_warrior.html`, `mountain_dung_dodger.html`, `birds_vs_robots.html`, `test_math.html`).
- This double-dispatch incremented `problemsSolved` twice (double the real count) and recomputed `accuracy` on an already-finished session.
- Fix: add an idempotency guard on `sessionActive` — if the session is already finished, `finishMathSession()` returns the current stats unchanged without modifying any state.

## Validation

All 5 behavioural proofs passed via Node.js:

1. **Double-finish bug fix** — `problemsSolved` equals `correctAnswers` (= 3) after the second call, not 6. PASS
2. **sessionActive guard** — `sessionActive` is `false` after finish. PASS
3. **Single finish still correct** — normal path (one call) still works. PASS
4. **Partial correct, double finish** — 2/3 correct: `problemsSolved` = 2, not 4. PASS
5. **Two sessions accumulate correctly** — `problemsSolved` = 6 after two complete sessions, not 12. PASS

Sanity sweep: only `math/mathTests.js` modified; no test removals, no dependency changes, no unintended scope expansion.

Closes #27