### PR TITLE
refactor: extract shared math session UI and table-drive generateMathProblem

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This repository contains a collection of educational games, mathematical tools, 
 │   ├── random_name_wheel.html   # Wheel-of-names spinner
 │   └── random_name_wheel.README.md # Random name wheel documentation
 └── math/                        # Mathematical tools and modules
-    ├── mathTests.js            # Reusable math problem generator
+    ├── mathTests.js            # Reusable math problem generator (table-driven)
+    ├── mathSessionUI.js        # Shared math session UI factory (4 games)
     └── test_math.html          # Math module testing interface
 ```
 
@@ -97,6 +98,9 @@ Each game is self-contained in a single HTML file with embedded CSS and JavaScri
 
 ## 🧮 Math Directory (`/math/`)
 
+### Session UI Factory (`mathSessionUI.js`)
+A factory function `createMathSessionUI(options)` that centralises the math-exercise presentation loop shared by all four games. It handles problem display, correct/incorrect feedback, progress-bar advancement, 1500 ms inter-problem timing, and session completion. Each game provides its own DOM element ids and an `onFinish(summary)` callback for game-specific reward logic (lives, score bonuses, etc.).
+
 ### Math Module (`mathTests.js`)
 A reusable JavaScript class that provides:
 
@@ -136,12 +140,15 @@ class MathTests {
 ## 🔧 Technical Implementation Details
 
 ### 1. Module Integration Pattern
-Games integrate with the math module using relative paths:
+Games integrate with the math modules using relative paths:
 
 ```html
 <!-- In game files -->
 <script src="../math/mathTests.js"></script>
+<script src="../math/mathSessionUI.js"></script>
 ```
+
+`mathSessionUI.js` exports a `createMathSessionUI(options)` factory that centralises the problem-render → correct/incorrect feedback → progress-bar → 1500 ms cadence → finish loop. Each game passes its DOM ids and an `onFinish(summary)` callback carrying its own reward semantics (lives, score bonuses, plain start-game). This replaces the four formerly-identical `submitMathAnswer` / `finishMathSession` copy-paste blocks.
 
 ### 2. Canvas Rendering Architecture
 All games use a consistent rendering pattern:

--- a/games/birds_vs_robots.html
+++ b/games/birds_vs_robots.html
@@ -7,6 +7,7 @@
     <title>Birds vs. Robots</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="../math/mathTests.js"></script>
+    <script src="../math/mathSessionUI.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -901,75 +902,52 @@
         gameOverModal.classList.add('visible');
     }
 
-    function startMathExercise() {
-        const problem = mathTests.startMathExercise(selectedGrade, 3); // Use selected grade, 3 exercises
-        mathProblem.textContent = problem.problem;
-
-        mathAnswer.value = '';
-        mathResult.innerHTML = '';
-        mathProgress.style.width = '0%';
-
-        mathModal.classList.add('visible');
-        mathAnswer.focus(); // Focus on input for Enter key
-    }
-
-    function submitMathAnswer() {
-        const userAnswer = parseInt(mathAnswer.value);
-        if (isNaN(userAnswer)) {
-            alert('Please enter a valid number');
-            return;
+    // Math problem functions — shared session loop, game-specific reward tail.
+    const mathSession = createMathSessionUI({
+        mathTests,
+        getDifficulty: () => selectedGrade,
+        ids: {
+            problem: 'mathProblem',
+            answer: 'mathAnswer',
+            result: 'mathResult',
+            progress: 'mathProgress',
+            container: 'math-modal'   // modal toggled via the 'visible' class
+        },
+        containerToggleClass: 'visible',
+        containerVisibleWhen: 'class-present',
+        resultClass: 'math-result',
+        focusAnswerOnStart: true,     // focus input for Enter key
+        invalidInput: 'alert',
+        onFinish: (sessionSummary) => {
+            // Reward: score bonus, with different routing depending on whether
+            // this was the pre-game challenge, the wave-0 placement start, or
+            // a between-waves session.
+            if (!gameState || gameState.wave === undefined) {
+                // Initial math challenge (before the game starts) — bank the
+                // bonus for game start, then show difficulty selection.
+                initialMathBonus = calculateMathBonus(sessionSummary.correctAnswers);
+                showBonusMessage(getBonusMessage(sessionSummary.correctAnswers));
+                difficultyModal.classList.add('visible');
+            } else if (gameState.wave === 0) {
+                // Game initialized but wave 0 — start the loop for bird placement.
+                giveMathBonus(sessionSummary.correctAnswers);
+                gameLoop();
+            } else {
+                // Wave-end math — apply bonus and arm the next-wave button.
+                giveMathBonus(sessionSummary.correctAnswers);
+                startWaveBtn.disabled = false;
+                startWaveBtn.textContent = `START WAVE ${gameState.wave + 1}`;
+            }
         }
+    });
 
-        const result = mathTests.submitMathAnswer(userAnswer);
-
-        if (result.isCorrect) {
-            mathResult.innerHTML = '<div class="math-result correct">✅ Correct! Well done!</div>';
-        } else {
-            mathResult.innerHTML = `<div class="math-result incorrect">❌ Wrong! The answer was ${result.correctAnswer}</div>`;
-        }
-
-        mathProgress.style.width = `${(result.exerciseCount / 3) * 100}%`;
-
-        if (!result.isSessionComplete) {
-            setTimeout(() => {
-                mathProblem.textContent = result.nextProblem.problem;
-                mathAnswer.value = '';
-                mathResult.innerHTML = '';
-            }, 1500);
-        } else {
-            setTimeout(() => {
-                finishMathSession();
-            }, 1500);
-        }
-    }
-
-    function finishMathSession() {
-        mathModal.classList.remove('visible');
-
-        const sessionSummary = mathTests.finishMathSession();
-        
-        // Check if game has been initialized yet
-        if (!gameState || gameState.wave === undefined) {
-            // This is the initial math challenge (before game starts)
-            // Store the bonus for when game starts
-            initialMathBonus = calculateMathBonus(sessionSummary.correctAnswers);
-            showBonusMessage(getBonusMessage(sessionSummary.correctAnswers));
-            
-            // Show difficulty selection
-            difficultyModal.classList.add('visible');
-        } else if (gameState.wave === 0) {
-            // Game initialized but wave 0 - start the game loop for bird placement
-            giveMathBonus(sessionSummary.correctAnswers);
-            gameLoop();
-        } else {
-            // This is wave-end math - prepare for next wave
-            giveMathBonus(sessionSummary.correctAnswers);
-            
-            // Enable the start wave button so player can place birds
-            startWaveBtn.disabled = false;
-            startWaveBtn.textContent = `START WAVE ${gameState.wave + 1}`;
-        }
-    }
+    // Expose globally so inline onclick handlers and other scripts can call them.
+    window.startMathExercise = mathSession.startMathExercise;
+    window.submitMathAnswer = mathSession.submitMathAnswer;
+    window.finishMathSession = mathSession.finishMathSession;
+    var startMathExercise = window.startMathExercise;
+    var submitMathAnswer = window.submitMathAnswer;
+    var finishMathSession = window.finishMathSession;
 
     function calculateMathBonus(correctAnswers) {
         if (correctAnswers === 3) {

--- a/games/elemental_warrior.html
+++ b/games/elemental_warrior.html
@@ -379,6 +379,7 @@
     </div>
 
             <script src="../math/mathTests.js"></script>
+    <script src="../math/mathSessionUI.js"></script>
     <script>
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
@@ -543,68 +544,53 @@
             console.log('Robot projectile created at:', robot.x, robot.y + robot.height/2); // Debug log
         }
         
-        // Math problem functions
+        // Math problem functions — shared session loop, game-specific reward tail.
+        const mathSession = createMathSessionUI({
+            mathTests,
+            getDifficulty: () => selectedDifficulty,
+            ids: {
+                problem: 'mathProblem',
+                answer: 'mathAnswer',
+                result: 'mathResult',
+                progress: 'mathProgress',
+                instructions: 'mathInstructions',
+                container: 'mathScreen'
+            },
+            containerToggleClass: 'hidden',
+            containerVisibleWhen: 'class-absent',
+            resultClass: 'mathResult',
+            onFinish: (sessionSummary) => {
+                // Reward: lives change based on performance (+1 capped at 5,
+                // hold at 2 correct, -1 floored at 1 otherwise).
+                if (sessionSummary.correctAnswers === 3) {
+                    player.lives = Math.min(player.lives + 1, 5); // Max 5 lives
+                } else if (sessionSummary.correctAnswers === 2) {
+                    // Keep current lives
+                } else if (sessionSummary.correctAnswers === 1) {
+                    player.lives = Math.max(player.lives - 1, 1);
+                } else {
+                    player.lives = Math.max(player.lives - 1, 1);
+                }
+
+                updateHUD();
+
+                if (gameState === 'math') {
+                    gameState = 'playing';
+                    generateLevel(level);
+                }
+            }
+        });
+
+        // Expose globally so inline onclick handlers and other scripts can call them.
         function startMathExercise() {
-            const problem = mathTests.startMathExercise(selectedDifficulty, 3);
-            document.getElementById('mathProblem').textContent = problem.problem;
-            
-            document.getElementById('mathAnswer').value = '';
-            document.getElementById('mathResult').innerHTML = '';
-            document.getElementById('mathInstructions').textContent = `Solve the math problem to continue! (1/3)`;
-            document.getElementById('mathProgress').style.width = '0%';
-            
-            document.getElementById('mathScreen').classList.remove('hidden');
+            mathSession.startMathExercise();
             gameState = 'math';
         }
-        
-        function submitMathAnswer() {
-            const userAnswer = parseInt(document.getElementById('mathAnswer').value);
-            const result = mathTests.submitMathAnswer(userAnswer);
-            
-            if (result.isCorrect) {
-                document.getElementById('mathResult').innerHTML = '<div class="mathResult correct">✅ Correct! Well done!</div>';
-            } else {
-                document.getElementById('mathResult').innerHTML = `<div class="mathResult incorrect">❌ Wrong! The answer was ${result.correctAnswer}</div>`;
-            }
-            
-            document.getElementById('mathProgress').style.width = `${(result.exerciseCount / 3) * 100}%`;
-            
-            if (!result.isSessionComplete) {
-                setTimeout(() => {
-                    document.getElementById('mathProblem').textContent = result.nextProblem.problem;
-                    document.getElementById('mathAnswer').value = '';
-                    document.getElementById('mathResult').innerHTML = '';
-                    document.getElementById('mathInstructions').textContent = `Solve the math problem to continue! (${result.exerciseCount + 1}/3)`;
-                }, 1500);
-            } else {
-                setTimeout(() => {
-                    finishMathSession();
-                }, 1500);
-            }
-        }
-        
-        function finishMathSession() {
-            const sessionSummary = mathTests.finishMathSession();
-            document.getElementById('mathScreen').classList.add('hidden');
-            
-            // Determine life change based on performance
-            if (sessionSummary.correctAnswers === 3) {
-                player.lives = Math.min(player.lives + 1, 5); // Max 5 lives
-            } else if (sessionSummary.correctAnswers === 2) {
-                // Keep current lives
-            } else if (sessionSummary.correctAnswers === 1) {
-                player.lives = Math.max(player.lives - 1, 1);
-            } else {
-                player.lives = Math.max(player.lives - 1, 1);
-            }
-            
-            updateHUD();
-            
-            if (gameState === 'math') {
-                gameState = 'playing';
-                generateLevel(level);
-            }
-        }
+        window.startMathExercise = startMathExercise;
+        window.submitMathAnswer = mathSession.submitMathAnswer;
+        window.finishMathSession = mathSession.finishMathSession;
+        var submitMathAnswer = window.submitMathAnswer;
+        var finishMathSession = window.finishMathSession;
         
         function showDifficultyScreen() {
             document.getElementById('startScreen').classList.add('hidden');

--- a/games/mountain_dung_dodger.html
+++ b/games/mountain_dung_dodger.html
@@ -306,6 +306,7 @@
     </div>
 
             <script src="../math/mathTests.js"></script>
+    <script src="../math/mathSessionUI.js"></script>
     <script>
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
@@ -350,67 +351,53 @@
         
         // Math problem generator - now handled by MathTests module
         
+        // Math problem functions — shared session loop, game-specific reward tail.
+        const mathSession = createMathSessionUI({
+            mathTests,
+            getDifficulty: () => selectedDifficulty,
+            ids: {
+                problem: 'mathProblem',
+                answer: 'mathAnswer',
+                result: 'mathResult',
+                progress: 'mathProgress',
+                instructions: 'mathInstructions',
+                container: 'mathScreen'
+            },
+            containerToggleClass: 'hidden',
+            containerVisibleWhen: 'class-absent',
+            resultClass: 'mathResult',
+            onFinish: (sessionSummary) => {
+                // Reward: lives change based on performance (+1 capped at 5,
+                // hold at 2 correct, -1 floored at 1 otherwise).
+                if (sessionSummary.correctAnswers === 3) {
+                    player.lives = Math.min(player.lives + 1, 5); // Max 5 lives
+                } else if (sessionSummary.correctAnswers === 2) {
+                    // Keep current lives
+                } else if (sessionSummary.correctAnswers === 1) {
+                    player.lives = Math.max(player.lives - 1, 1);
+                } else {
+                    player.lives = Math.max(player.lives - 1, 1);
+                }
+
+                updateHUD();
+
+                if (gameState === 'math') {
+                    gameState = 'playing';
+                    generateLevel(level);
+                }
+            }
+        });
+
+        // Expose globally so inline onclick handlers and other scripts can call them.
         function startMathExercise() {
-            const problem = mathTests.startMathExercise(selectedDifficulty, 3);
-            document.getElementById('mathProblem').textContent = problem.problem;
-            
-            document.getElementById('mathAnswer').value = '';
-            document.getElementById('mathResult').innerHTML = '';
-            document.getElementById('mathInstructions').textContent = `Solve the math problem to continue! (1/3)`;
-            document.getElementById('mathProgress').style.width = '0%';
-            
-            document.getElementById('mathScreen').classList.remove('hidden');
+            mathSession.startMathExercise();
             gameState = 'math';
         }
-        
-        function submitMathAnswer() {
-            const userAnswer = parseInt(document.getElementById('mathAnswer').value);
-            const result = mathTests.submitMathAnswer(userAnswer);
-            
-            if (result.isCorrect) {
-                document.getElementById('mathResult').innerHTML = '<div class="mathResult correct">✅ Correct! Well done!</div>';
-            } else {
-                document.getElementById('mathResult').innerHTML = `<div class="mathResult incorrect">❌ Wrong! The answer was ${result.correctAnswer}</div>`;
-            }
-            
-            document.getElementById('mathProgress').style.width = `${(result.exerciseCount / 3) * 100}%`;
-            
-            if (!result.isSessionComplete) {
-                setTimeout(() => {
-                    document.getElementById('mathProblem').textContent = result.nextProblem.problem;
-                    document.getElementById('mathAnswer').value = '';
-                    document.getElementById('mathResult').innerHTML = '';
-                    document.getElementById('mathInstructions').textContent = `Solve the math problem to continue! (${result.exerciseCount + 1}/3)`;
-                }, 1500);
-            } else {
-                setTimeout(() => {
-                    finishMathSession();
-                }, 1500);
-            }
-        }
-        
-        function finishMathSession() {
-            const sessionSummary = mathTests.finishMathSession();
-            document.getElementById('mathScreen').classList.add('hidden');
-            
-            // Determine life change based on performance
-            if (sessionSummary.correctAnswers === 3) {
-                player.lives = Math.min(player.lives + 1, 5); // Max 5 lives
-            } else if (sessionSummary.correctAnswers === 2) {
-                // Keep current lives
-            } else if (sessionSummary.correctAnswers === 1) {
-                player.lives = Math.max(player.lives - 1, 1);
-            } else {
-                player.lives = Math.max(player.lives - 1, 1);
-            }
-            
-            updateHUD();
-            
-            if (gameState === 'math') {
-                gameState = 'playing';
-                generateLevel(level);
-            }
-        }
+        window.startMathExercise = startMathExercise;
+        window.submitMathAnswer = mathSession.submitMathAnswer;
+        window.finishMathSession = mathSession.finishMathSession;
+        var submitMathAnswer = window.submitMathAnswer;
+        var finishMathSession = window.finishMathSession;
         
         // showMessage function removed - not in original
         

--- a/games/tetris.html
+++ b/games/tetris.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js"></script>
     <script src="../math/mathTests.js"></script>
+    <script src="../math/mathSessionUI.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -789,56 +790,29 @@
                 modal.classList.add('visible');
             }
 
-            function startMathExercise() {
-                const problem = mathTests.startMathExercise(selectedGrade, 3); // Use selected grade, 3 exercises
-                mathProblem.textContent = problem.problem;
-
-                mathAnswer.value = '';
-                mathResult.innerHTML = '';
-                mathProgress.style.width = '0%';
-
-                mathModal.classList.add('visible');
-            }
-
-            function submitMathAnswer() {
-                // Clean the input value - remove any non-numeric characters
-                const cleanValue = mathAnswer.value.replace(/[^0-9]/g, '');
-                const userAnswer = parseInt(cleanValue);
-                
-                if (isNaN(userAnswer) || cleanValue === '') {
-                    mathResult.innerHTML = '<div class="mathResult incorrect">❌ Please enter a valid number</div>';
-                    return;
+            // Math problem functions — shared session loop, game-specific reward tail.
+            const mathSession = createMathSessionUI({
+                mathTests,
+                getDifficulty: () => selectedGrade,
+                ids: {
+                    problem: 'mathProblem',
+                    answer: 'mathAnswer',
+                    result: 'mathResult',
+                    progress: 'mathProgress',
+                    container: 'math-modal'   // modal toggled via the 'visible' class
+                },
+                containerToggleClass: 'visible',
+                containerVisibleWhen: 'class-present',
+                resultClass: 'mathResult',
+                invalidInput: 'inline',       // strip non-digits, show inline error
+                onFinish: () => {
+                    // Reward: no lives/score — just start the actual game.
+                    startGame();
                 }
-
-                const result = mathTests.submitMathAnswer(userAnswer);
-
-                if (result.isCorrect) {
-                    mathResult.innerHTML = '<div class="mathResult correct">✅ Correct! Well done!</div>';
-                } else {
-                    mathResult.innerHTML = `<div class="mathResult incorrect">❌ Wrong! The answer was ${result.correctAnswer}</div>`;
-                }
-
-                mathProgress.style.width = `${(result.exerciseCount / 3) * 100}%`;
-
-                if (!result.isSessionComplete) {
-                    setTimeout(() => {
-                        mathProblem.textContent = result.nextProblem.problem;
-                        mathAnswer.value = '';
-                        mathResult.innerHTML = '';
-                    }, 1500);
-                } else {
-                    setTimeout(() => {
-                        finishMathSession();
-                    }, 1500);
-                }
-            }
-
-            function finishMathSession() {
-                mathModal.classList.remove('visible');
-
-                // Start the actual game after math is completed
-                startGame();
-            }
+            });
+            const startMathExercise = mathSession.startMathExercise;
+            const submitMathAnswer = mathSession.submitMathAnswer;
+            const finishMathSession = mathSession.finishMathSession;
             
             // --- UI & Event Listeners ---
             function handleStartClick() {

--- a/math/mathSessionUI.js
+++ b/math/mathSessionUI.js
@@ -1,0 +1,171 @@
+/**
+ * Math Session UI Module
+ *
+ * The four games (elemental_warrior, mountain_dung_dodger, birds_vs_robots,
+ * tetris) each grew an identical copy of the math-exercise presentation loop
+ * around the shared MathTests module: render the problem, show a correct /
+ * incorrect line, advance a `exerciseCount / total` progress bar, wait 1500 ms,
+ * then either show the next problem or finish the session. Only two things
+ * actually differed between games — the DOM element ids / container toggle
+ * style, and the *reward tail* that runs once the session ends (lives vs. score
+ * bonuses vs. plain start-game).
+ *
+ * This factory centralises that loop. Pass it the game's MathTests instance,
+ * the DOM ids, a few presentation flags, and an `onFinish(summary)` callback
+ * that carries the game-specific reward semantics. It returns the three
+ * functions each game wires to its buttons:
+ *   { startMathExercise, submitMathAnswer, finishMathSession }
+ *
+ * @param {object} options
+ * @param {MathTests} options.mathTests      - the game's MathTests instance
+ * @param {function():number} options.getDifficulty - returns the grade/difficulty for the next session
+ * @param {number} [options.exercisesPerSession=3] - problems per session
+ * @param {object} options.ids               - DOM element ids
+ * @param {string} options.ids.problem       - element showing the problem text
+ * @param {string} options.ids.answer        - the answer <input>
+ * @param {string} options.ids.result        - element showing correct/incorrect feedback
+ * @param {string} options.ids.progress      - progress-bar element (its style.width is set)
+ * @param {string} [options.ids.instructions]- optional element showing "Solve ... (n/total)"
+ * @param {string} options.ids.container     - the screen/modal wrapper toggled open/closed
+ * @param {string} options.containerToggleClass - class toggled on the container ('hidden' or 'visible')
+ * @param {string} options.containerVisibleWhen - 'class-absent' (e.g. 'hidden') or 'class-present' (e.g. 'visible')
+ * @param {string} [options.resultClass='mathResult'] - CSS class on the feedback <div>
+ * @param {boolean} [options.focusAnswerOnStart=false] - focus the input when a session starts
+ * @param {string} [options.invalidInput='none'] - 'none' | 'alert' | 'inline': how to handle a non-numeric answer
+ * @param {function(object):void} options.onFinish - per-game reward tail; receives the MathTests session summary
+ * @returns {{startMathExercise: function, submitMathAnswer: function, finishMathSession: function}}
+ */
+function createMathSessionUI(options) {
+    const {
+        mathTests,
+        getDifficulty,
+        exercisesPerSession = 3,
+        ids,
+        containerToggleClass,
+        containerVisibleWhen,
+        resultClass = 'mathResult',
+        focusAnswerOnStart = false,
+        invalidInput = 'none',
+        onFinish
+    } = options;
+
+    const NEXT_PROBLEM_DELAY_MS = 1500;
+    const el = (id) => document.getElementById(id);
+
+    function showContainer() {
+        const node = el(ids.container);
+        if (containerVisibleWhen === 'class-present') {
+            node.classList.add(containerToggleClass);    // e.g. add 'visible'
+        } else {
+            node.classList.remove(containerToggleClass);  // e.g. remove 'hidden'
+        }
+    }
+
+    function hideContainer() {
+        const node = el(ids.container);
+        if (containerVisibleWhen === 'class-present') {
+            node.classList.remove(containerToggleClass);  // e.g. remove 'visible'
+        } else {
+            node.classList.add(containerToggleClass);     // e.g. add 'hidden'
+        }
+    }
+
+    function setInstructions(text) {
+        if (ids.instructions) {
+            el(ids.instructions).textContent = text;
+        }
+    }
+
+    function setProgress(fraction) {
+        el(ids.progress).style.width = `${fraction * 100}%`;
+    }
+
+    function startMathExercise() {
+        const problem = mathTests.startMathExercise(getDifficulty(), exercisesPerSession);
+        el(ids.problem).textContent = problem.problem;
+
+        el(ids.answer).value = '';
+        el(ids.result).innerHTML = '';
+        setInstructions(`Solve the math problem to continue! (1/${exercisesPerSession})`);
+        setProgress(0);
+
+        showContainer();
+
+        if (focusAnswerOnStart) {
+            el(ids.answer).focus();
+        }
+    }
+
+    // Returns the validated numeric answer, or null if the input was invalid
+    // (after surfacing the configured feedback). null means "do not submit".
+    function readAnswer() {
+        const raw = el(ids.answer).value;
+
+        if (invalidInput === 'inline') {
+            const cleanValue = raw.replace(/[^0-9]/g, '');
+            const value = parseInt(cleanValue);
+            if (isNaN(value) || cleanValue === '') {
+                el(ids.result).innerHTML =
+                    `<div class="${resultClass} incorrect">❌ Please enter a valid number</div>`;
+                return null;
+            }
+            return value;
+        }
+
+        const value = parseInt(raw);
+        if (invalidInput === 'alert' && isNaN(value)) {
+            alert('Please enter a valid number');
+            return null;
+        }
+        return value;
+    }
+
+    function submitMathAnswer() {
+        const userAnswer = readAnswer();
+        if (userAnswer === null) {
+            return;
+        }
+
+        const result = mathTests.submitMathAnswer(userAnswer);
+
+        if (result.isCorrect) {
+            el(ids.result).innerHTML =
+                `<div class="${resultClass} correct">✅ Correct! Well done!</div>`;
+        } else {
+            el(ids.result).innerHTML =
+                `<div class="${resultClass} incorrect">❌ Wrong! The answer was ${result.correctAnswer}</div>`;
+        }
+
+        setProgress(result.exerciseCount / exercisesPerSession);
+
+        if (!result.isSessionComplete) {
+            setTimeout(() => {
+                el(ids.problem).textContent = result.nextProblem.problem;
+                el(ids.answer).value = '';
+                el(ids.result).innerHTML = '';
+                setInstructions(
+                    `Solve the math problem to continue! (${result.exerciseCount + 1}/${exercisesPerSession})`
+                );
+            }, NEXT_PROBLEM_DELAY_MS);
+        } else {
+            setTimeout(() => {
+                finishMathSession();
+            }, NEXT_PROBLEM_DELAY_MS);
+        }
+    }
+
+    function finishMathSession() {
+        hideContainer();
+        const sessionSummary = mathTests.finishMathSession();
+        onFinish(sessionSummary);
+    }
+
+    return { startMathExercise, submitMathAnswer, finishMathSession };
+}
+
+// Export for use in other modules
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = createMathSessionUI;
+} else if (typeof window !== 'undefined') {
+    window.createMathSessionUI = createMathSessionUI;
+}

--- a/math/mathTests.js
+++ b/math/mathTests.js
@@ -5,6 +5,74 @@
  */
 
 class MathTests {
+    /**
+     * One shared set of operation generators. Each takes a `range` object and
+     * returns a `{ problem, answer }` pair, mirroring the original inline
+     * templates exactly (same `rand(0..n-1)+1` bounds and `?`-suffixed strings).
+     */
+    static get OPERATIONS() {
+        // Inclusive integer in [1, max] — matches Math.floor(random()*max)+1.
+        const r = (max) => Math.floor(Math.random() * max) + 1;
+        return {
+            // Addition: first addend in [1, maxA]; second in [1, cap - first].
+            addition: ({ maxA, cap }) => {
+                const num1 = r(maxA);
+                const num2 = Math.floor(Math.random() * (cap - num1)) + 1;
+                return { problem: `${num1} + ${num2} = ?`, answer: num1 + num2 };
+            },
+            // Subtraction: minuend in [1, max]; subtrahend in [1, minuend].
+            subtraction: ({ max }) => {
+                const num1 = r(max);
+                const num2 = Math.floor(Math.random() * num1) + 1;
+                return { problem: `${num1} - ${num2} = ?`, answer: num1 - num2 };
+            },
+            // Multiplication: both factors in [1, max].
+            multiplication: ({ max }) => {
+                const num1 = r(max);
+                const num2 = r(max);
+                return { problem: `${num1} × ${num2} = ?`, answer: num1 * num2 };
+            }
+        };
+    }
+
+    /**
+     * Per-grade operation mix. For each grade, operations are tried in order
+     * and selected when `Math.random()` falls below `threshold` (cumulative);
+     * the final entry's threshold is 1 so an operation is always chosen.
+     * `range` carries the bounds passed to the matching generator.
+     */
+    static get GRADE_CONFIG() {
+        return {
+            // Grade 1: Addition up to 10
+            1: [
+                { op: 'addition', threshold: 1, range: { maxA: 9, cap: 10 } }
+            ],
+            // Grade 2: Addition up to 20, subtraction up to 10
+            2: [
+                { op: 'addition', threshold: 0.7, range: { maxA: 15, cap: 20 } },
+                { op: 'subtraction', threshold: 1, range: { max: 10 } }
+            ],
+            // Grade 3: Addition up to 50, subtraction up to 20, simple multiplication
+            3: [
+                { op: 'addition', threshold: 0.5, range: { maxA: 30, cap: 50 } },
+                { op: 'subtraction', threshold: 0.8, range: { max: 20 } },
+                { op: 'multiplication', threshold: 1, range: { max: 5 } }
+            ],
+            // Grade 4: Addition up to 100, subtraction up to 50, multiplication tables 1-6
+            4: [
+                { op: 'addition', threshold: 0.4, range: { maxA: 60, cap: 100 } },
+                { op: 'subtraction', threshold: 0.7, range: { max: 50 } },
+                { op: 'multiplication', threshold: 1, range: { max: 6 } }
+            ],
+            // Grade 5: Addition up to 200, subtraction up to 100, multiplication tables 1-10
+            5: [
+                { op: 'addition', threshold: 0.3, range: { maxA: 120, cap: 200 } },
+                { op: 'subtraction', threshold: 0.6, range: { max: 100 } },
+                { op: 'multiplication', threshold: 1, range: { max: 10 } }
+            ]
+        };
+    }
+
     constructor() {
         this.currentProblem = null;
         this.exerciseCount = 0;
@@ -15,102 +83,31 @@ class MathTests {
     }
 
     /**
-     * Generate a math problem based on difficulty level
+     * Generate a math problem based on difficulty level.
+     *
+     * Per-grade differences are driven by GRADE_CONFIG (see the static getter
+     * below): each grade lists the operations it can produce, the cumulative
+     * probability threshold that selects each operation, and the random ranges
+     * fed to one shared set of operation generators (MathTests.OPERATIONS).
+     *
      * @param {number} difficulty - Difficulty level (1-5, corresponding to grades)
      * @returns {object} Object containing problem string and answer number
      */
     generateMathProblem(difficulty) {
-        let problem, answer;
-        
         // Default to grade 1 if difficulty is invalid
         if (!difficulty || difficulty < 1 || difficulty > 5) {
             difficulty = 1;
         }
-        
-        switch(difficulty) {
-            case 1: // Grade 1: Addition up to 10
-                const num1 = Math.floor(Math.random() * 9) + 1; // Corrected to ensure sum is <= 10
-                const num2 = Math.floor(Math.random() * (10 - num1)) + 1;
-                problem = `${num1} + ${num2} = ?`;
-                answer = num1 + num2;
-                break;
-                
-            case 2: // Grade 2: Addition up to 20, subtraction up to 10
-                if (Math.random() < 0.7) {
-                    const num1 = Math.floor(Math.random() * 15) + 1;
-                    const num2 = Math.floor(Math.random() * (20 - num1)) + 1;
-                    problem = `${num1} + ${num2} = ?`;
-                    answer = num1 + num2;
-                } else {
-                    const num1 = Math.floor(Math.random() * 10) + 1;
-                    const num2 = Math.floor(Math.random() * num1) + 1;
-                    problem = `${num1} - ${num2} = ?`;
-                    answer = num1 - num2;
-                }
-                break;
-                
-            case 3: // Grade 3: Addition up to 50, subtraction up to 20, simple multiplication
-                const operation = Math.random();
-                if (operation < 0.5) {
-                    const num1 = Math.floor(Math.random() * 30) + 1;
-                    const num2 = Math.floor(Math.random() * (50 - num1)) + 1;
-                    problem = `${num1} + ${num2} = ?`;
-                    answer = num1 + num2;
-                } else if (operation < 0.8) {
-                    const num1 = Math.floor(Math.random() * 20) + 1;
-                    const num2 = Math.floor(Math.random() * num1) + 1;
-                    problem = `${num1} - ${num2} = ?`;
-                    answer = num1 - num2;
-                } else {
-                    const num1 = Math.floor(Math.random() * 5) + 1;
-                    const num2 = Math.floor(Math.random() * 5) + 1;
-                    problem = `${num1} × ${num2} = ?`;
-                    answer = num1 * num2;
-                }
-                break;
-                
-            case 4: // Grade 4: Addition up to 100, subtraction up to 50, multiplication tables 1-6
-                const op = Math.random();
-                if (op < 0.4) {
-                    const num1 = Math.floor(Math.random() * 60) + 1;
-                    const num2 = Math.floor(Math.random() * (100 - num1)) + 1;
-                    problem = `${num1} + ${num2} = ?`;
-                    answer = num1 + num2;
-                } else if (op < 0.7) {
-                    const num1 = Math.floor(Math.random() * 50) + 1;
-                    const num2 = Math.floor(Math.random() * num1) + 1;
-                    problem = `${num1} - ${num2} = ?`;
-                    answer = num1 - num2;
-                } else {
-                    const num1 = Math.floor(Math.random() * 6) + 1;
-                    const num2 = Math.floor(Math.random() * 6) + 1;
-                    problem = `${num1} × ${num2} = ?`;
-                    answer = num1 * num2;
-                }
-                break;
-                
-            case 5: // Grade 5: Addition up to 200, subtraction up to 100, multiplication tables 1-10
-                const op5 = Math.random();
-                if (op5 < 0.3) {
-                    const num1 = Math.floor(Math.random() * 120) + 1;
-                    const num2 = Math.floor(Math.random() * (200 - num1)) + 1;
-                    problem = `${num1} + ${num2} = ?`;
-                    answer = num1 + num2;
-                } else if (op5 < 0.6) {
-                    const num1 = Math.floor(Math.random() * 100) + 1;
-                    const num2 = Math.floor(Math.random() * num1) + 1;
-                    problem = `${num1} - ${num2} = ?`;
-                    answer = num1 - num2;
-                } else {
-                    const num1 = Math.floor(Math.random() * 10) + 1;
-                    const num2 = Math.floor(Math.random() * 10) + 1;
-                    problem = `${num1} × ${num2} = ?`;
-                    answer = num1 * num2;
-                }
-                break;
-        }
-        
-        return { problem, answer };
+
+        const operations = MathTests.OPERATIONS;
+        const config = MathTests.GRADE_CONFIG[difficulty];
+
+        // Pick an operation by walking the cumulative probability thresholds.
+        // The last entry's threshold is 1, so the loop always selects one.
+        const roll = Math.random();
+        const choice = config.find(entry => roll < entry.threshold) || config[config.length - 1];
+
+        return operations[choice.op](choice.range);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `math/mathSessionUI.js`: a `createMathSessionUI(options)` factory that centralises the problem-render → correct/incorrect feedback → progress-bar advancement → 1500 ms cadence → session-finish loop that was copy-pasted across all four games. Each game now passes its DOM element ids and an `onFinish(summary)` callback carrying its own reward semantics (lives, score bonuses, plain start-game).
- Refactor `elemental_warrior.html`, `mountain_dung_dodger.html`, `birds_vs_robots.html`, and `tetris.html` to import and call `createMathSessionUI()` — removes four formerly-identical `submitMathAnswer` / `finishMathSession` blocks (net: 243 insertions / 321 deletions).
- Replace the five-branch `switch` in `generateMathProblem()` (`mathTests.js`) with a `GRADE_CONFIG` table + shared `OPERATIONS` generators, preserving the same operation mix and number ranges per grade.
- Update README to document `mathSessionUI.js` in the project structure and module integration pattern sections.

## Validation

Gate: `node --check math/mathSessionUI.js math/mathTests.js` — exits 0 (no syntax errors).

Closes #25