### PR TITLE
refactor: extract livesReward helper and drop math-session global aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository contains a collection of educational games, mathematical tools, 
 └── math/                        # Mathematical tools and modules
     ├── mathTests.js            # Reusable math problem generator (table-driven)
     ├── mathSessionUI.js        # Shared math session UI factory (4 games)
+    ├── livesReward.js          # Shared lives-reward bookkeeping (platformers)
     └── test_math.html          # Math module testing interface
 ```
 
@@ -99,7 +100,10 @@ Each game is self-contained in a single HTML file with embedded CSS and JavaScri
 ## 🧮 Math Directory (`/math/`)
 
 ### Session UI Factory (`mathSessionUI.js`)
-A factory function `createMathSessionUI(options)` that centralises the math-exercise presentation loop shared by all four games. It handles problem display, correct/incorrect feedback, progress-bar advancement, 1500 ms inter-problem timing, and session completion. Each game provides its own DOM element ids and an `onFinish(summary)` callback for game-specific reward logic (lives, score bonuses, etc.).
+A factory function `createMathSessionUI(options)` that centralises the math-exercise presentation loop shared by all four games. It handles problem display, correct/incorrect feedback, progress-bar advancement, 1500 ms inter-problem timing, and session completion. Each game provides its own DOM element ids and an `onFinish(summary)` callback for game-specific reward logic (lives, score bonuses, etc.). Games wire their submit button via `addEventListener` against the factory's returned handlers — no global aliasing.
+
+### Lives Reward (`livesReward.js`)
+A helper `livesRewardFromSession(player, sessionSummary)` that owns the lives bookkeeping the two platformers (`mountain_dung_dodger`, `elemental_warrior`) apply after a math session: 3 correct → +1 life (capped at 5), 2 correct → no change, otherwise → −1 life (floored at 1). Both games call it from their `onFinish` callback before their own state-transition tail, replacing a block that was byte-for-byte identical in each.
 
 ### Math Module (`mathTests.js`)
 A reusable JavaScript class that provides:

--- a/games/birds_vs_robots.html
+++ b/games/birds_vs_robots.html
@@ -413,7 +413,7 @@
         <p style="margin: 1rem 0; text-align: center;">Solve the math problem to continue!</p>
         <div class="math-problem" id="mathProblem"></div>
         <input type="number" class="math-input" id="mathAnswer" placeholder="?" min="0" max="999">
-        <button class="math-submit" onclick="submitMathAnswer()">SUBMIT</button>
+        <button class="math-submit" id="mathSubmit">SUBMIT</button>
         <div id="mathResult"></div>
     </div>
 </div>
@@ -941,13 +941,11 @@
         }
     });
 
-    // Expose globally so inline onclick handlers and other scripts can call them.
-    window.startMathExercise = mathSession.startMathExercise;
-    window.submitMathAnswer = mathSession.submitMathAnswer;
-    window.finishMathSession = mathSession.finishMathSession;
-    var startMathExercise = window.startMathExercise;
-    var submitMathAnswer = window.submitMathAnswer;
-    var finishMathSession = window.finishMathSession;
+    // Local bindings for in-script calls; submit button is wired via
+    // addEventListener below (no globals needed).
+    const startMathExercise = mathSession.startMathExercise;
+    const submitMathAnswer = mathSession.submitMathAnswer;
+    document.getElementById('mathSubmit').addEventListener('click', submitMathAnswer);
 
     function calculateMathBonus(correctAnswers) {
         if (correctAnswers === 3) {

--- a/games/elemental_warrior.html
+++ b/games/elemental_warrior.html
@@ -365,7 +365,7 @@
             <p id="mathInstructions">Solve the math problem to continue!</p>
             <div class="mathProblem" id="mathProblem"></div>
             <input type="number" class="mathInput" id="mathAnswer" placeholder="?" min="0" max="999">
-            <button class="mathSubmit" onclick="submitMathAnswer()">Submit Answer</button>
+            <button class="mathSubmit" id="mathSubmit">Submit Answer</button>
             <div id="mathResult"></div>
         </div>
         
@@ -380,6 +380,7 @@
 
             <script src="../math/mathTests.js"></script>
     <script src="../math/mathSessionUI.js"></script>
+    <script src="../math/livesReward.js"></script>
     <script>
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
@@ -560,17 +561,9 @@
             containerVisibleWhen: 'class-absent',
             resultClass: 'mathResult',
             onFinish: (sessionSummary) => {
-                // Reward: lives change based on performance (+1 capped at 5,
-                // hold at 2 correct, -1 floored at 1 otherwise).
-                if (sessionSummary.correctAnswers === 3) {
-                    player.lives = Math.min(player.lives + 1, 5); // Max 5 lives
-                } else if (sessionSummary.correctAnswers === 2) {
-                    // Keep current lives
-                } else if (sessionSummary.correctAnswers === 1) {
-                    player.lives = Math.max(player.lives - 1, 1);
-                } else {
-                    player.lives = Math.max(player.lives - 1, 1);
-                }
+                // Reward lives based on performance (shared rule), then run the
+                // per-game state-transition tail.
+                livesRewardFromSession(player, sessionSummary);
 
                 updateHUD();
 
@@ -581,16 +574,14 @@
             }
         });
 
-        // Expose globally so inline onclick handlers and other scripts can call them.
+        // Local bindings for in-script calls; submit button is wired via
+        // addEventListener below (no globals needed).
+        const submitMathAnswer = mathSession.submitMathAnswer;
         function startMathExercise() {
             mathSession.startMathExercise();
             gameState = 'math';
         }
-        window.startMathExercise = startMathExercise;
-        window.submitMathAnswer = mathSession.submitMathAnswer;
-        window.finishMathSession = mathSession.finishMathSession;
-        var submitMathAnswer = window.submitMathAnswer;
-        var finishMathSession = window.finishMathSession;
+        document.getElementById('mathSubmit').addEventListener('click', submitMathAnswer);
         
         function showDifficultyScreen() {
             document.getElementById('startScreen').classList.add('hidden');

--- a/games/mountain_dung_dodger.html
+++ b/games/mountain_dung_dodger.html
@@ -292,7 +292,7 @@
             <p id="mathInstructions">Solve the math problem to continue!</p>
             <div class="mathProblem" id="mathProblem"></div>
             <input type="number" class="mathInput" id="mathAnswer" placeholder="?" min="0" max="999">
-            <button class="mathSubmit" onclick="submitMathAnswer()">Submit Answer</button>
+            <button class="mathSubmit" id="mathSubmit">Submit Answer</button>
             <div id="mathResult"></div>
         </div>
         
@@ -307,6 +307,7 @@
 
             <script src="../math/mathTests.js"></script>
     <script src="../math/mathSessionUI.js"></script>
+    <script src="../math/livesReward.js"></script>
     <script>
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
@@ -367,17 +368,9 @@
             containerVisibleWhen: 'class-absent',
             resultClass: 'mathResult',
             onFinish: (sessionSummary) => {
-                // Reward: lives change based on performance (+1 capped at 5,
-                // hold at 2 correct, -1 floored at 1 otherwise).
-                if (sessionSummary.correctAnswers === 3) {
-                    player.lives = Math.min(player.lives + 1, 5); // Max 5 lives
-                } else if (sessionSummary.correctAnswers === 2) {
-                    // Keep current lives
-                } else if (sessionSummary.correctAnswers === 1) {
-                    player.lives = Math.max(player.lives - 1, 1);
-                } else {
-                    player.lives = Math.max(player.lives - 1, 1);
-                }
+                // Reward lives based on performance (shared rule), then run the
+                // per-game state-transition tail.
+                livesRewardFromSession(player, sessionSummary);
 
                 updateHUD();
 
@@ -388,16 +381,14 @@
             }
         });
 
-        // Expose globally so inline onclick handlers and other scripts can call them.
+        // Local bindings for in-script calls; submit button is wired via
+        // addEventListener below (no globals needed).
+        const submitMathAnswer = mathSession.submitMathAnswer;
         function startMathExercise() {
             mathSession.startMathExercise();
             gameState = 'math';
         }
-        window.startMathExercise = startMathExercise;
-        window.submitMathAnswer = mathSession.submitMathAnswer;
-        window.finishMathSession = mathSession.finishMathSession;
-        var submitMathAnswer = window.submitMathAnswer;
-        var finishMathSession = window.finishMathSession;
+        document.getElementById('mathSubmit').addEventListener('click', submitMathAnswer);
         
         // showMessage function removed - not in original
         

--- a/math/livesReward.js
+++ b/math/livesReward.js
@@ -1,0 +1,37 @@
+/**
+ * Lives-Reward Helper
+ *
+ * The two platformer-style games (mountain_dung_dodger, elemental_warrior)
+ * reward the player with lives based on how a math session went, using an
+ * identical rule:
+ *
+ *   3 correct → +1 life (capped at 5)
+ *   2 correct → no change
+ *   1 or 0 correct → -1 life (floored at 1)
+ *
+ * This was previously hand-rolled, byte-for-byte identical, inside each game's
+ * `onFinish` callback. Extracting it here keeps each game's `onFinish` purely
+ * about *what to do after* lives are computed (updateHUD, state transition).
+ *
+ * @param {{lives:number}} player        - the game's player object (mutated in place)
+ * @param {{correctAnswers:number}} sessionSummary - the MathTests session summary
+ * @returns {number} the player's new lives count (also written to player.lives)
+ */
+function livesRewardFromSession(player, sessionSummary) {
+    if (sessionSummary.correctAnswers === 3) {
+        player.lives = Math.min(player.lives + 1, 5); // Max 5 lives
+    } else if (sessionSummary.correctAnswers === 2) {
+        // Keep current lives
+    } else {
+        // 1 or 0 correct → lose a life, floored at 1
+        player.lives = Math.max(player.lives - 1, 1);
+    }
+    return player.lives;
+}
+
+// Export for use in other modules
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = livesRewardFromSession;
+} else if (typeof window !== 'undefined') {
+    window.livesRewardFromSession = livesRewardFromSession;
+}


### PR DESCRIPTION
## Summary

Clears the two duplication findings in #32.

- **Finding 1 — identical lives-reward block in two games:** new `math/livesReward.js` exporting `livesRewardFromSession(player, sessionSummary)` (3 correct → +1 capped at 5, 2 → no-op, else → −1 floored at 1). `mountain_dung_dodger` and `elemental_warrior` call it from their `onFinish` before their own state-transition tail, replacing a byte-for-byte-identical copy in each. The `=== 1`/`else` branches (both −1) collapse into one `else` — behaviorally identical.
- **Finding 2 — globals-exposure boilerplate in three games:** chose **option B** — replace the inline `onclick="submitMathAnswer()"` handlers with `addEventListener` wiring and drop the `window.*` export + var-alias boilerplate entirely. Only `submitMathAnswer` ever needed a global; `finishMathSession` was exported but referenced nowhere (dead exposure). This keeps the global namespace clean and aligns all three games with `birds_vs_robots`'s existing `addEventListener` pattern, rather than giving the shared factory a global-pollution option that would dirty every consumer.

README updated: `livesReward.js` added to the `math/` module tree and section, plus a note on the `addEventListener` wiring.

## Validation

`node --check` on `livesReward.js`, `mathSessionUI.js`, and each game's extracted inline `<script>` — all pass. No formal test runner exists (README: "open the HTML in a browser"); manual browser smoke-test recommended.

Closes #32