### PR TITLE
chore: remove stale audit findings

### DIFF
--- a/games/elemental_warrior.html
+++ b/games/elemental_warrior.html
@@ -492,7 +492,6 @@
             // Always create a projectile in the direction the player is facing
             const direction = player.facing;
             createProjectile(player.x + (direction > 0 ? player.width : 0), player.y + player.height/2, direction, currentElement.color, 'player');
-            console.log('Player projectile created at:', player.x + (direction > 0 ? player.width : 0), player.y + player.height/2); // Debug log
             
             updateHUD();
         }
@@ -542,7 +541,6 @@
         // Robot shooting
         function robotShoot(robot) {
             createProjectile(robot.x, robot.y + robot.height/2, -1, robot.elementColor, 'enemy');
-            console.log('Robot projectile created at:', robot.x, robot.y + robot.height/2); // Debug log
         }
         
         // Math problem functions — shared session loop, game-specific reward tail.
@@ -595,7 +593,6 @@
         
         // Generate level
         function generateLevel(levelNum) {
-            console.log('Generating level:', levelNum); // Debug log
             platforms = [];
             robots = [];
             particles = [];
@@ -665,8 +662,6 @@
                 height: 60
             };
             
-            console.log('Level generated with', robots.length, 'robots'); // Debug log
-            
             // Reset player
             player.x = 50;
             player.y = 355;
@@ -727,7 +722,6 @@
                 if (robot.lastShot > 60 && Math.random() < 0.02) { // Increased frequency and probability
                     robotShoot(robot);
                     robot.lastShot = 0;
-                    console.log('Robot shot!', robot.x, robot.y); // Debug log
                 }
             }
             
@@ -921,7 +915,6 @@
                 const pixelSize = Math.max(1, Math.floor(size));
                 const element = ELEMENTS.find(e => e.name === robot.element);
                 const elementColor = element ? element.color : '#666666';
-                console.log('Drawing robot at:', robot.x, robot.y, 'size:', size); // Debug log
                 
                 // Shadow
                 ctx.fillStyle = '#000000';
@@ -1011,7 +1004,6 @@
             for (let proj of projectiles) {
                 ctx.fillStyle = proj.color;
                 ctx.fillRect(proj.x, proj.y, proj.width, proj.height);
-                console.log('Drawing projectile at:', proj.x, proj.y, 'from:', proj.from); // Debug log
             }
             
             // Player

--- a/games/mountain_dung_dodger.html
+++ b/games/mountain_dung_dodger.html
@@ -350,8 +350,6 @@
         let keys = {};
         let touchControls = { left: false, right: false, jump: false };
         
-        // Math problem generator - now handled by MathTests module
-        
         // Math problem functions — shared session loop, game-specific reward tail.
         const mathSession = createMathSessionUI({
             mathTests,
@@ -389,8 +387,6 @@
             gameState = 'math';
         }
         document.getElementById('mathSubmit').addEventListener('click', submitMathAnswer);
-        
-        // showMessage function removed - not in original
         
         function showDifficultyScreen() {
             document.getElementById('startScreen').classList.add('hidden');


### PR DESCRIPTION
## Summary

- Removes all seven shipped `console.log(...); // Debug log` statements from `elemental_warrior.html`, including the robot/projectile draw-loop logs that spammed the console every frame.
- Removes the two stale placeholder comments from `mountain_dung_dodger.html` that only documented previously moved or deleted code.
- Confirms the old `var submitMathAnswer` / `var finishMathSession` alias finding is already resolved in the current source; both games now use local `const submitMathAnswer` bindings wired through `addEventListener`.

## Validation

- **Pattern sweep**: `Select-String` across `games/elemental_warrior.html` and `games/mountain_dung_dodger.html` for `console.log`, `Debug log`, the two placeholder comments, and the old `var submitMathAnswer` / `var finishMathSession` aliases → no matches.
- **Diff gate**: `git diff --check origin/main..HEAD` → OK.
- No automated test runner exists for this static HTML repo; this is dead-code/comment cleanup only.

Closes #33