### PR TITLE
docs: remove fabricated/aspirational README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,33 +231,6 @@ Start a local server (see "Local Development Server" below), then navigate to th
 - Test responsive design across different screen sizes
 - Validate touch controls on mobile devices
 
-## 🎯 Performance Optimization
-
-### Rendering Optimizations
-- **Object Culling**: Only renders visible objects
-- **Efficient Collision**: Simple rectangle-based detection
-- **Particle Management**: Limits active particle count
-- **Canvas Optimization**: Minimizes state changes
-
-### Memory Management
-- **Object Pooling**: Reuses objects instead of creating new ones
-- **Garbage Collection**: Minimizes memory allocation
-- **Resource Cleanup**: Removes unused objects promptly
-
-## 🔮 Future Enhancements
-
-### Technical Improvements
-- **WebGL Rendering**: Better graphics performance
-- **Procedural Generation**: More varied level designs
-- **AI Opponents**: Computer-controlled characters
-- **Network Features**: Online leaderboards and sharing
-
-### Architecture Enhancements
-- **Build System**: Webpack or Vite for bundling
-- **TypeScript**: Type safety and better tooling
-- **Testing Framework**: Jest or Vitest for unit tests
-- **CI/CD**: Automated testing and deployment
-
 ## 🛠️ Development Setup
 
 ### Prerequisites
@@ -283,39 +256,9 @@ npx serve .
 php -S localhost:8000
 ```
 
-## 📚 Learning Resources
-
-### Concepts Demonstrated
-- **Game Loop Architecture**: How games maintain smooth animation
-- **State Management**: Controlling different game screens
-- **Event Handling**: Responding to user input
-- **Collision Detection**: Basic physics simulation
-- **Canvas Graphics**: Drawing and animating on web pages
-- **Mobile Development**: Touch interfaces and responsive design
-- **Modular Design**: Separating concerns and creating reusable components
-
-### Educational Value
-This project demonstrates several important programming concepts:
-- **Separation of Concerns**: Games vs. math logic
-- **Module Design**: Reusable components
-- **Responsive Design**: Mobile-first development
-- **Performance Optimization**: Efficient rendering and memory management
-- **User Experience**: Intuitive interfaces and smooth interactions
-
 ## 🤝 Contributing
 
-### Code Style
-- Use consistent indentation (2 or 4 spaces)
-- Follow existing naming conventions
-- Add JSDoc comments for complex functions
-- Test changes across different browsers
-
-### Pull Request Process
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test thoroughly
-5. Submit a pull request with clear description
+See `CLAUDE.md` for the real conventions: stack, layout rules, how to add a game, and commit/PR guidelines.
 
 ---
 


### PR DESCRIPTION
## Summary

- Drops the **Performance Optimization** section (lines 234-245) that asserted object pooling and object culling — a repo-wide grep for `pool`/`cull` across `games/` and `math/` returns zero hits. The actual rendering pattern (`update()→draw()→requestAnimationFrame()` + simple rectangle collision) is already accurately documented in the Canvas Rendering Architecture section.
- Drops the **Future Enhancements** section (lines 247-259) — it proposed WebGL, TypeScript, Webpack/Vite, and CI/CD, which directly contradicts the project's `CLAUDE.md` identity: "No build step, no framework, no `package.json`", "dependency-light".
- Replaces the **Learning Resources** and **Contributing / Pull Request Process** sections (lines 286-318) — generic fork-and-PR boilerplate that doesn't match the actual workflow — with a single pointer to `CLAUDE.md`, which already states the real conventions concisely.

## Validation

- Confirmed `grep -ri "pool\|cull" games/ math/` returns zero hits (fabricated claims verified absent).
- `git diff main...HEAD` reviewed: only `README.md`, only the three targeted removals + one replacement line, no unintended changes.
- Static-site project: no build step, no test suite, no linter config — correctness verified by diff inspection against the issue's explicit scope.

Closes #40