### PR TITLE
docs: fix MathTests API block and wheel README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ class MathTests {
     finishMathSession()
     getSessionStats()
     reset()
+    setDifficulty(difficulty)
+    getDifficultyDescription(difficulty)
 }
 ```
 

--- a/funstuff/random_name_wheel.README.md
+++ b/funstuff/random_name_wheel.README.md
@@ -45,7 +45,7 @@ An interactive HTML-based random name picker that works like a wheel of fortune.
 - Pure HTML, CSS, and JavaScript (no external dependencies)
 - Canvas-based wheel rendering for smooth performance
 - Easing animations for realistic spin physics
-- Local storage of results (persists during session)
+- Winners list kept in memory (resets on page reload)
 - Mobile-friendly touch interactions
 
 ## 📝 Usage Examples


### PR DESCRIPTION
## Summary

- Add `setDifficulty(difficulty)` and `getDifficultyDescription(difficulty)` to the `MathTests` API block in README.md (lines 119-130); both methods exist in `math/mathTests.js:226,237` and were missing from the documented surface, misleading readers about the class's public interface.
- Replace the false `"Local storage of results (persists during session)"` claim in `funstuff/random_name_wheel.README.md` with `"Winners list kept in memory (resets on page reload)"`; `random_name_wheel.html` uses an in-memory `results = []` array and makes zero `localStorage`/`sessionStorage` calls (confirmed by grep).

## Validation

- Confirmed both methods exist at `math/mathTests.js:226,237` via grep.
- Confirmed zero `localStorage`/`sessionStorage` calls in `random_name_wheel.html` via grep.
- `git diff main...HEAD` reviewed — exactly two targeted edits, nothing outside stated scope.
- Docs-only change; no CI workflows exist in this repo.

Closes #42